### PR TITLE
minor fixes on V2

### DIFF
--- a/client/src/components/Card3dScene.tsx
+++ b/client/src/components/Card3dScene.tsx
@@ -19,6 +19,7 @@ import { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
 import { Euler, Vector3 } from "three";
 import { match } from "ts-pattern";
+import customColorUrl from "../assets/custom_color.jpg?url";
 import { Animation, animate } from "../utils/animation";
 import { easeOutExpo } from "../utils/easings";
 
@@ -128,7 +129,7 @@ const CardScene = ({ step, ownerName, color, logo, logoScale }: Props) => {
   const ratioRef = useRef(1);
   const stepRef = useRef(step);
   const [orbitEnabled, setOrbitEnabled] = useState(() => step === "share");
-  const customTexture = useTexture("/assets/custom_color.jpg", setTextureColorSpace);
+  const customTexture = useTexture(customColorUrl, setTextureColorSpace);
 
   const cameraPositionAnimation = useRef<Animation<Vector3>>();
   // animate card rotation instead of camera to be able to use orbitControls and rotation animation at the same time

--- a/client/src/components/ShareModal.tsx
+++ b/client/src/components/ShareModal.tsx
@@ -7,6 +7,8 @@ import { Link } from "@swan-io/lake/src/components/Link";
 import { Space } from "@swan-io/lake/src/components/Space";
 import { colors } from "@swan-io/lake/src/constants/design";
 import { Image, StyleSheet } from "react-native";
+import linkedInIconUrl from "../assets/linkedin.svg?url";
+import xIconUrl from "../assets/x.svg?url";
 import { t } from "../utils/i18n";
 
 const styles = StyleSheet.create({
@@ -55,7 +57,7 @@ export const ShareModal = ({ visible, configId, onPressClose }: Props) => {
       <Space height={16} />
 
       <Link to={linkedInUrl} target="_blank" style={styles.link}>
-        <Image source={{ uri: "/assets/linkedin.svg" }} style={styles.logo} alt="LinkedIn" />
+        <Image source={{ uri: linkedInIconUrl }} style={styles.logo} alt="LinkedIn" />
         <Space width={4} />
         <LakeText color={colors.live[500]}>{t("shareModal.shareOnLinkedIn")}</LakeText>
         <Space width={4} />
@@ -65,7 +67,7 @@ export const ShareModal = ({ visible, configId, onPressClose }: Props) => {
       <Space height={16} />
 
       <Link to={xUrl} target="_blank" style={styles.link}>
-        <Image source={{ uri: "/assets/x.svg" }} style={styles.logo} alt="X" />
+        <Image source={{ uri: xIconUrl }} style={styles.logo} alt="X" />
         <Space width={4} />
         <LakeText color={colors.live[500]}>{t("shareModal.shareOnX")}</LakeText>
         <Space width={4} />

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -1,9 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="shortcut icon" href="/assets/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="viewport-fit=cover, width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
 
     <title>Create branded cards with Swan’s Card Design Studio</title>
     <meta property="description" content="Create branded cards with Swan’s Card Design Studio" />

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build-server": "tsc --project server/tsconfig.json",
     "build-client": "vite build --config client/vite.config.ts",
     "build": "yarn clean && yarn build-server && yarn build-client",
-    "start": "node server/dist/index.js"
+    "start": "node -r dotenv/config server/dist/index.js"
   },
   "lint-staged": {
     "*": "prettier --ignore-unknown --write",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build-server": "tsc --project server/tsconfig.json",
     "build-client": "vite build --config client/vite.config.ts",
     "build": "yarn clean && yarn build-server && yarn build-client",
-    "start": "node -r dotenv/config server/dist/index.js"
+    "start": "node server/dist/index.js"
   },
   "lint-staged": {
     "*": "prettier --ignore-unknown --write",


### PR DESCRIPTION
This PR brings 2 fixes:
- when the app is build, urls in `assets` folder weren't accessible and making the app crash. This is fixed by using Vite import instead of absolute url.
- on iOS, focusing an input automatically zoom in the page and the app was cropped until the user unzoom manually. Now zoom is prevent thanks to `viewport` meta tag in `index.html`