### PR TITLE
V2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,15 @@ COPY . .
 
 RUN yarn add shx -W --ignore-scripts && \
     yarn install --ignore-scripts && \
-    yarn playwright install --with-deps && \
     yarn build
+
+###
+
+FROM mcr.microsoft.com/playwright:v1.41.1-jammy
+
+WORKDIR /app
+
+COPY --chown=node:node --from=builder /app ./
 
 ENV NODE_ENV=production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ COPY . .
 
 RUN yarn add shx -W --ignore-scripts && \
     yarn install --ignore-scripts && \
+    yarn playwright install && \
     yarn build
 
 ###

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,11 @@ COPY . .
 
 RUN yarn add shx -W --ignore-scripts && \
     yarn install --ignore-scripts && \
-    yarn playwright install && \
+    yarn playwright install --with-deps && \
     yarn build
-
-###
-
-FROM cgr.dev/chainguard/node:latest
-
-WORKDIR /app
-
-COPY --chown=node:node --from=builder /app ./
 
 ENV NODE_ENV=production
 
 EXPOSE 8080
 
-CMD ["/usr/bin/npm", "start"]
+CMD ["npm", "start"]

--- a/client/src/app.tsx
+++ b/client/src/app.tsx
@@ -15,6 +15,7 @@ import { Router } from "./utils/routes";
 import { AsyncData } from "@swan-io/boxed";
 import { isNotNullish } from "@swan-io/lake/src/utils/nullish";
 import { createYourBrandSvg } from "./utils/svg";
+import { LoadConfigOverlay } from "./components/LoadConfigOverlay";
 const Card3dScene = lazy(() => import("./components/Card3dScene"));
 
 const styles = StyleSheet.create({
@@ -25,12 +26,13 @@ const styles = StyleSheet.create({
 });
 
 export const App = () => {
-  const route = Router.useRoute(["ConfigCard", "Share", "WebsiteDemo"]);
+  const route = Router.useRoute(["ConfigCard", "Share", "Screenshot", "WebsiteDemo"]);
   const [step, setStep] = useState<ConfigStep>(() =>
     match(route?.name)
       .returnType<ConfigStep>()
       .with("ConfigCard", () => "welcome")
       .with("Share", () => "share")
+      .with("Screenshot", () => "screenshot")
       .with("WebsiteDemo", () => "website-demo")
       .with(P.nullish, () => "welcome")
       .exhaustive(),
@@ -108,6 +110,9 @@ export const App = () => {
         </Suspense>
 
         {match(route)
+          .with({ name: "Screenshot" }, ({ params }) => (
+            <LoadConfigOverlay configId={params.configId} onLoaded={setCardConfig} />
+          ))
           .with({ name: "Share" }, ({ params }) => (
             <ShareOverlay
               configId={params.configId}

--- a/client/src/components/Card3dScene.tsx
+++ b/client/src/components/Card3dScene.tsx
@@ -86,6 +86,12 @@ const cameraPositions: Record<
     },
     rotation: new Vector3(0, 0, 0),
   },
+  screenshot: {
+    getPosition: () => {
+      return new Vector3(-0.6, 0, 9);
+    },
+    rotation: new Vector3(0, 0.35, 0),
+  },
   "website-demo": {
     getPosition: ratio => {
       const z = 18 / Math.min(1, ratio * 1.7);

--- a/client/src/components/Card3dScene.tsx
+++ b/client/src/components/Card3dScene.tsx
@@ -19,6 +19,7 @@ import { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
 import { Euler, Vector3 } from "three";
 import { match } from "ts-pattern";
+import customColorUrl from "../assets/custom_color.jpg?url";
 import { Animation, animate } from "../utils/animation";
 import { easeOutExpo } from "../utils/easings";
 
@@ -128,7 +129,7 @@ const CardScene = ({ step, ownerName, color, logo, logoScale }: Props) => {
   const ratioRef = useRef(1);
   const stepRef = useRef(step);
   const [orbitEnabled, setOrbitEnabled] = useState(() => step === "share");
-  const customTexture = useTexture("/assets/custom_color.jpg", setTextureColorSpace);
+  const customTexture = useTexture(customColorUrl, setTextureColorSpace);
 
   const cameraPositionAnimation = useRef<Animation<Vector3>>();
   // animate card rotation instead of camera to be able to use orbitControls and rotation animation at the same time

--- a/client/src/components/Card3dScene.tsx
+++ b/client/src/components/Card3dScene.tsx
@@ -88,7 +88,7 @@ const cameraPositions: Record<
   },
   screenshot: {
     getPosition: () => {
-      return new Vector3(-0.6, 0, 9);
+      return new Vector3(-0.6, 0, 10);
     },
     rotation: new Vector3(0, 0.35, 0),
   },

--- a/client/src/components/CardNotFound.tsx
+++ b/client/src/components/CardNotFound.tsx
@@ -1,0 +1,59 @@
+import { LakeButton } from "@swan-io/lake/src/components/LakeButton";
+import { LakeHeading } from "@swan-io/lake/src/components/LakeHeading";
+import { Space } from "@swan-io/lake/src/components/Space";
+import { colors } from "@swan-io/lake/src/constants/design";
+import { StyleSheet, View } from "react-native";
+import { t } from "../utils/i18n";
+import { TrackPressable } from "./TrackPressable";
+
+const styles = StyleSheet.create({
+  container: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    width: "100%",
+    height: "100%",
+    backgroundColor: colors.gray[0],
+  },
+  errorContainer: {
+    margin: "auto",
+  },
+  reloadButton: {
+    alignSelf: "flex-start",
+  },
+});
+
+export const CardNotFound = () => {
+  return (
+    <View style={styles.container}>
+      <View style={styles.errorContainer}>
+        <LakeHeading level={1} variant="h1">
+          {t("share.failedToLoad.title")}
+        </LakeHeading>
+
+        <Space height={16} />
+
+        <LakeHeading level={2} variant="h3" color={colors.gray[600]}>
+          {t("share.failedToLoad.subtitle")}
+        </LakeHeading>
+
+        <Space height={16} />
+
+        <TrackPressable name="share.reload-after-failure">
+          <LakeButton
+            color="live"
+            size="small"
+            icon="arrow-counterclockwise-filled"
+            iconPosition="end"
+            style={styles.reloadButton}
+            onPress={() => {
+              window.location.reload();
+            }}
+          >
+            {t("share.failedToLoad.reload")}
+          </LakeButton>
+        </TrackPressable>
+      </View>
+    </View>
+  );
+};

--- a/client/src/components/ConfigSteps.tsx
+++ b/client/src/components/ConfigSteps.tsx
@@ -416,13 +416,13 @@ export const CompletedStep = ({
   onLogoScaleChange,
 }: CompletedStepProps) => {
   const [editing, setEditing] = useState(false);
-  const [shareState, setShareState] = useState<AsyncData<Result<{ configId: string }, unknown>>>(
+  const [shareState, setShareState] = useState<AsyncData<Result<CreateConfigResponse, unknown>>>(
     AsyncData.NotAsked(),
   );
   const [shareModalClosed, setShareModalClosed] = useState(false);
 
   const configId = match(shareState)
-    .with(AsyncData.P.Done(Result.P.Ok(P.select())), ({ configId }) => Option.Some(configId))
+    .with(AsyncData.P.Done(Result.P.Ok(P.select())), ({ id }) => Option.Some(id))
     .otherwise(() => Option.None());
 
   const shareConfig = () => {
@@ -449,7 +449,7 @@ export const CompletedStep = ({
       .then(async response => {
         const data = await response.json(); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
 
-        if (isMatching({ configId: P.string }, data)) {
+        if (isMatching({ id: P.string, screenshotUrl: null, shareUrl: P.string }, data)) {
           setShareState(AsyncData.Done(Result.Ok(data)));
         } else {
           setShareState(AsyncData.Done(Result.Error(data)));

--- a/client/src/components/LoadConfigOverlay.tsx
+++ b/client/src/components/LoadConfigOverlay.tsx
@@ -1,0 +1,43 @@
+import { LoadingView } from "@swan-io/lake/src/components/LoadingView";
+import { colors } from "@swan-io/lake/src/constants/design";
+import { StyleSheet, View } from "react-native";
+import { useCardConfig } from "../utils/cardConfig";
+import { CardNotFound } from "./CardNotFound";
+
+const styles = StyleSheet.create({
+  container: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    width: "100%",
+    height: "100%",
+    backgroundColor: colors.gray[0],
+  },
+});
+
+type Props = {
+  configId: string;
+  onLoaded: (config: CardConfig) => void;
+};
+
+export const LoadConfigOverlay = ({ configId, onLoaded }: Props) => {
+  const state = useCardConfig(configId, onLoaded);
+
+  return state.match({
+    NotAsked: () => (
+      <View style={styles.container}>
+        <LoadingView />
+      </View>
+    ),
+    Loading: () => (
+      <View style={styles.container}>
+        <LoadingView />
+      </View>
+    ),
+    Done: result =>
+      result.match({
+        Ok: () => null,
+        Error: () => <CardNotFound />,
+      }),
+  });
+};

--- a/client/src/components/ShareModal.tsx
+++ b/client/src/components/ShareModal.tsx
@@ -7,6 +7,8 @@ import { Link } from "@swan-io/lake/src/components/Link";
 import { Space } from "@swan-io/lake/src/components/Space";
 import { colors } from "@swan-io/lake/src/constants/design";
 import { Image, StyleSheet } from "react-native";
+import linkedInIconUrl from "../assets/linkedin.svg?url";
+import xIconUrl from "../assets/x.svg?url";
 import { t } from "../utils/i18n";
 
 const styles = StyleSheet.create({
@@ -55,7 +57,7 @@ export const ShareModal = ({ visible, configId, onPressClose }: Props) => {
       <Space height={16} />
 
       <Link to={linkedInUrl} target="_blank" style={styles.link}>
-        <Image source={{ uri: "/assets/linkedin.svg" }} style={styles.logo} alt="LinkedIn" />
+        <Image source={{ uri: linkedInIconUrl }} style={styles.logo} alt="LinkedIn" />
         <Space width={4} />
         <LakeText color={colors.live[500]}>{t("shareModal.shareOnLinkedIn")}</LakeText>
         <Space width={4} />
@@ -65,7 +67,7 @@ export const ShareModal = ({ visible, configId, onPressClose }: Props) => {
       <Space height={16} />
 
       <Link to={xUrl} target="_blank" style={styles.link}>
-        <Image source={{ uri: "/assets/x.svg" }} style={styles.logo} alt="X" />
+        <Image source={{ uri: xIconUrl }} style={styles.logo} alt="X" />
         <Space width={4} />
         <LakeText color={colors.live[500]}>{t("shareModal.shareOnX")}</LakeText>
         <Space width={4} />

--- a/client/src/components/ShareOverlay.tsx
+++ b/client/src/components/ShareOverlay.tsx
@@ -1,18 +1,16 @@
-import { AsyncData, Result } from "@swan-io/boxed";
 import { Box } from "@swan-io/lake/src/components/Box";
 import { LakeButton } from "@swan-io/lake/src/components/LakeButton";
-import { LakeHeading } from "@swan-io/lake/src/components/LakeHeading";
 import { LoadingView } from "@swan-io/lake/src/components/LoadingView";
 import { Space } from "@swan-io/lake/src/components/Space";
 import { colors } from "@swan-io/lake/src/constants/design";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { StyleSheet, View } from "react-native";
-import { P, match } from "ts-pattern";
 import { Except } from "type-fest";
 import { t } from "../utils/i18n";
-import { convertStringToSvg } from "../utils/svg";
 import { ShareModal } from "./ShareModal";
 import { TrackPressable } from "./TrackPressable";
+import { CardNotFound } from "./CardNotFound";
+import { useCardConfig } from "../utils/cardConfig";
 
 const styles = StyleSheet.create({
   container: {
@@ -22,12 +20,6 @@ const styles = StyleSheet.create({
     width: "100%",
     height: "100%",
     backgroundColor: colors.gray[0],
-  },
-  errorContainer: {
-    margin: "auto",
-  },
-  reloadButton: {
-    alignSelf: "flex-start",
   },
   buttonsContainer: {
     position: "absolute",
@@ -48,64 +40,8 @@ type Props = {
   onLoaded: (config: CardConfig) => void;
 };
 
-type ConfigApiResponse = Except<CardConfig, "logo"> & {
-  logo: string;
-};
-
 export const ShareOverlay = ({ configId, onStartNewDesign, onLoaded }: Props) => {
-  const [state, setState] = useState<AsyncData<Result<void, unknown>>>(AsyncData.NotAsked());
-
-  useEffect(() => {
-    setState(AsyncData.Loading());
-
-    const abortController = new AbortController();
-    const signal = abortController.signal;
-
-    fetch(`/api/config/${configId}`, { signal })
-      .then(async response => {
-        if (!response.ok) {
-          return { ok: false };
-        }
-
-        const data: ConfigApiResponse = await response.json(); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
-
-        const logo = match(data.logo)
-          .with(P.string.startsWith("<svg"), svg => convertStringToSvg(svg))
-          .otherwise(base64Uri => {
-            // if logo does not start with <svg, it is a base64 encoded png
-            const image = new Image();
-            image.src = base64Uri;
-            return image;
-          });
-
-        return {
-          ok: true,
-          data: {
-            ...data,
-            logo,
-          },
-        };
-      })
-      .then(result => {
-        match(result)
-          .with({ data: P.not(P.nullish) }, ({ data }) => {
-            setState(AsyncData.Done(Result.Ok(undefined)));
-            // "/api/config/:id" returns a CardConfig if request is successful
-            onLoaded(data);
-          })
-          .otherwise(() => {
-            setState(AsyncData.Done(Result.Error(undefined)));
-          });
-      })
-      .catch(error => {
-        console.error(error);
-        setState(AsyncData.Done(Result.Error(undefined)));
-      });
-
-    return () => {
-      abortController.abort();
-    };
-  }, [configId, onLoaded]);
+  const state = useCardConfig(configId, onLoaded);
 
   return state.match({
     NotAsked: () => (
@@ -166,40 +102,5 @@ const ShareOverlayContent = ({ configId, onStartNewDesign }: Except<Props, "onLo
         onPressClose={() => setShareModalOpened(false)}
       />
     </>
-  );
-};
-
-const CardNotFound = () => {
-  return (
-    <View style={styles.container}>
-      <View style={styles.errorContainer}>
-        <LakeHeading level={1} variant="h1">
-          {t("share.failedToLoad.title")}
-        </LakeHeading>
-
-        <Space height={16} />
-
-        <LakeHeading level={2} variant="h3" color={colors.gray[600]}>
-          {t("share.failedToLoad.subtitle")}
-        </LakeHeading>
-
-        <Space height={16} />
-
-        <TrackPressable name="share.reload-after-failure">
-          <LakeButton
-            color="live"
-            size="small"
-            icon="arrow-counterclockwise-filled"
-            iconPosition="end"
-            style={styles.reloadButton}
-            onPress={() => {
-              window.location.reload();
-            }}
-          >
-            {t("share.failedToLoad.reload")}
-          </LakeButton>
-        </TrackPressable>
-      </View>
-    </View>
   );
 };

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -1,9 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="shortcut icon" href="/assets/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="viewport-fit=cover, width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
 
     <title>Create branded cards with Swan’s Card Design Studio</title>
     <meta property="description" content="Create branded cards with Swan’s Card Design Studio" />

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -17,6 +17,12 @@ type CardConfig = {
   color: "Silver" | "Black" | "Custom";
 };
 
+type CreateConfigResponse = {
+  id: string;
+  screenshotUrl: string | null;
+  shareUrl: string;
+};
+
 type Size = {
   width: number;
   height: number;

--- a/client/src/types/index.d.ts
+++ b/client/src/types/index.d.ts
@@ -1,6 +1,14 @@
 /// <reference types="vite/client" />
 
-type ConfigStep = "welcome" | "name" | "logo" | "color" | "completed" | "share" | "website-demo";
+type ConfigStep =
+  | "welcome"
+  | "name"
+  | "logo"
+  | "color"
+  | "completed"
+  | "share"
+  | "screenshot"
+  | "website-demo";
 
 type CardConfig = {
   name: string;

--- a/client/src/utils/cardConfig.ts
+++ b/client/src/utils/cardConfig.ts
@@ -1,0 +1,70 @@
+import { AsyncData, Result } from "@swan-io/boxed";
+import { useEffect, useState } from "react";
+import { P, match } from "ts-pattern";
+import { Except } from "type-fest";
+import { convertStringToSvg } from "./svg";
+
+type ConfigApiResponse = Except<CardConfig, "logo"> & {
+  logo: string;
+};
+
+export const useCardConfig = (
+  configId: string,
+  onLoaded: (config: CardConfig) => void,
+): AsyncData<Result<CardConfig, unknown>> => {
+  const [state, setState] = useState<AsyncData<Result<CardConfig, unknown>>>(AsyncData.NotAsked());
+
+  useEffect(() => {
+    setState(AsyncData.Loading());
+
+    const abortController = new AbortController();
+    const signal = abortController.signal;
+
+    fetch(`/api/config/${configId}`, { signal })
+      .then(async response => {
+        if (!response.ok) {
+          return { ok: false };
+        }
+
+        const data: ConfigApiResponse = await response.json(); // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+
+        const logo = match(data.logo)
+          .with(P.string.startsWith("<svg"), svg => convertStringToSvg(svg))
+          .otherwise(base64Uri => {
+            // if logo does not start with <svg, it is a base64 encoded png
+            const image = new Image();
+            image.src = base64Uri;
+            return image;
+          });
+
+        return {
+          ok: true,
+          data: {
+            ...data,
+            logo,
+          },
+        };
+      })
+      .then(result => {
+        match(result)
+          .with({ data: P.not(P.nullish) }, ({ data }) => {
+            setState(AsyncData.Done(Result.Ok(data)));
+            // "/api/config/:id" returns a CardConfig if request is successful
+            onLoaded(data);
+          })
+          .otherwise(() => {
+            setState(AsyncData.Done(Result.Error(undefined)));
+          });
+      })
+      .catch(error => {
+        console.error(error);
+        setState(AsyncData.Done(Result.Error(undefined)));
+      });
+
+    return () => {
+      abortController.abort();
+    };
+  }, [configId, onLoaded]);
+
+  return state;
+};

--- a/client/src/utils/routes.ts
+++ b/client/src/utils/routes.ts
@@ -3,6 +3,7 @@ import { createRouter } from "@swan-io/chicane";
 export const Router = createRouter({
   ConfigCard: "/",
   Share: "/share/:configId",
+  Screenshot: "/screenshot/:configId",
   WebsiteDemo: "/website-demo?:backgroundColor&:cardColor&:cardHolderName",
 });
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "prettier": "3.0.3",
     "prettier-plugin-organize-imports": "3.2.3",
     "terser": "5.21.0",
-    "tsx": "3.13.0",
+    "tsx": "4.7.0",
     "type-fest": "4.4.0",
     "typescript": "5.2.2",
     "valienv": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build-server": "tsc --project server/tsconfig.json",
     "build-client": "vite build --config client/vite.config.ts",
     "build": "yarn clean && yarn build-server && yarn build-client",
-    "start": "node server/dist/index.js"
+    "start": "node -r dotenv/config server/dist/index.js"
   },
   "lint-staged": {
     "*": "prettier --ignore-unknown --write",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build-server": "tsc --project server/tsconfig.json",
     "build-client": "vite build --config client/vite.config.ts",
     "build": "yarn clean && yarn build-server && yarn build-client",
-    "start": "node -r dotenv/config server/dist/index.js"
+    "start": "node server/dist/index.js"
   },
   "lint-staged": {
     "*": "prettier --ignore-unknown --write",

--- a/server/package.json
+++ b/server/package.json
@@ -28,6 +28,7 @@
     "get-port": "7.0.0",
     "lodash": "4.17.21",
     "pathe": "1.1.1",
+    "playwright": "1.41.1",
     "ts-pattern": "5.0.5",
     "valienv": "0.5.0",
     "zod": "3.22.4"

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.428.0",
+    "@fastify/multipart": "8.1.0",
     "@fastify/reply-from": "9.4.0",
     "@fastify/sensible": "5.3.0",
     "@fastify/static": "6.11.2",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -36,9 +36,9 @@ const start = async () => {
 
     const body = parsedBody.data;
 
-    const configId = await saveCardConfig(body);
+    const configInfo = await saveCardConfig(body);
 
-    return reply.status(201).send({ configId });
+    return reply.status(201).send(configInfo);
   });
 
   app.get("/api/config/:id", async (request, reply) => {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -12,12 +12,17 @@ import {
   createConfigSchema,
   getScreenshot,
   parseMultiPartFormData,
+  startBrowser,
 } from "./utils/cardConfig";
 import { clientEnv, env } from "./utils/env";
 
 const PORT = 8080;
 
 const start = async () => {
+  console.log("Starting browser...");
+  await startBrowser();
+  console.log("Browser started");
+
   const app = fastify({
     logger: {},
   });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,7 +5,12 @@ import fastify from "fastify";
 import fs from "fs";
 import path from "pathe";
 import { createViteDevServer } from "./client/devServer";
-import { cardConfigSchema, getCardConfig, saveCardConfig } from "./utils/cardConfig";
+import {
+  getCardConfig,
+  saveCardConfig,
+  createConfigSchema,
+  getScreenshot,
+} from "./utils/cardConfig";
 import { clientEnv, env } from "./utils/env";
 
 const PORT = 8080;
@@ -23,7 +28,7 @@ const start = async () => {
   });
 
   app.post("/api/config", async (request, reply) => {
-    const parsedBody = cardConfigSchema.safeParse(request.body);
+    const parsedBody = createConfigSchema.safeParse(request.body);
 
     if (!parsedBody.success) {
       return reply.badRequest();
@@ -46,6 +51,21 @@ const start = async () => {
       None: () => reply.notFound(),
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       Some: config => reply.status(200).send(config),
+    });
+  });
+
+  app.get("/api/config/:id/screenshot", async (request, reply) => {
+    // @ts-expect-error
+    const configId: string = request.params.id; // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+
+    const screenshot = await getScreenshot(configId);
+
+    return screenshot.match({
+      None: () => reply.notFound(),
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      Some: stream => {
+        return reply.type("image/png").header("cache-control", `public, max-age=0`).send(stream);
+      },
     });
   });
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -18,7 +18,9 @@ import { clientEnv, env } from "./utils/env";
 const PORT = 8080;
 
 const start = async () => {
-  const app = fastify();
+  const app = fastify({
+    logger: {},
+  });
 
   await app.register(multipart);
   await app.register(sensible);

--- a/server/src/utils/cardConfig.ts
+++ b/server/src/utils/cardConfig.ts
@@ -109,6 +109,10 @@ const saveCardScreenshot = async (id: string, screenshot: Buffer): Promise<void>
   });
 };
 
+/**
+ * This function can be used only when the config is already saved to s3.
+ * It start a browser opening the design studio and take a screenshot.
+ */
 const generateScreenshot = async (id: string): Promise<Buffer> => {
   const browser = await chromium.launch();
   const context = await browser.newContext();
@@ -117,6 +121,13 @@ const generateScreenshot = async (id: string): Promise<Buffer> => {
   await page.goto(`${APP_URL}/screenshot/${id}`);
 
   await page.waitForLoadState("networkidle");
+
+  // The card design studio has a cookie banner that we need to close to take a screenshot
+  const button = await page.$("text=Reject All");
+  if (button !== null) {
+    await button.click();
+  }
+
   await page.waitForTimeout(1000);
 
   return page.screenshot();

--- a/server/src/utils/cardConfig.ts
+++ b/server/src/utils/cardConfig.ts
@@ -14,6 +14,8 @@ const credentials =
     : undefined;
 
 const s3 = new S3({
+  endpoint: env.S3_ENDPOINT.defined === true ? env.S3_ENDPOINT.value : undefined,
+  forcePathStyle: env.S3_ENDPOINT.defined === true,
   credentials,
   region: env.AWS_REGION,
 });

--- a/server/src/utils/cardConfig.ts
+++ b/server/src/utils/cardConfig.ts
@@ -5,6 +5,8 @@ import snakeCase from "lodash/snakeCase";
 import { z } from "zod";
 import { env } from "./env";
 
+const APP_URL = "https://card-design-studio.swan.io";
+
 const credentials =
   env.AWS_ACCESS_KEY_ID.defined === true && env.AWS_SECRET_ACCESS_KEY.defined === true
     ? {
@@ -22,6 +24,18 @@ const s3 = new S3({
 
 const getConfigKey = (id: string): string => `card-configs/${id}`;
 const getConfigFileKey = (id: string): string => `${getConfigKey(id)}/config.json`;
+const getScreenshotFileKey = (id: string): string => `${getConfigKey(id)}/screenshot.png`;
+
+export const createConfigSchema = z.object({
+  name: z.string().min(1),
+  logo: z.string(),
+  logoScale: z.number().min(0).max(1),
+  color: z.union([z.literal("Silver"), z.literal("Black"), z.literal("Custom")]),
+  generateScreenshot: z.boolean().optional(),
+  overwrite: z.boolean().optional(),
+});
+
+export type CreateConfig = z.infer<typeof createConfigSchema>;
 
 export const cardConfigSchema = z.object({
   name: z.string().min(1),
@@ -31,6 +45,33 @@ export const cardConfigSchema = z.object({
 });
 
 export type CardConfig = z.infer<typeof cardConfigSchema>;
+
+export type CardConfigInfo = CardConfig & {
+  shareUrl: string;
+  screenshotUrl: string | null;
+};
+
+const isScreenshotExists = async (id: string): Promise<boolean> => {
+  const data = await s3.listObjectsV2({
+    Bucket: env.S3_BUCKET_NAME,
+    Prefix: getScreenshotFileKey(id),
+  });
+  const contents = data.Contents ?? [];
+
+  return contents.length > 0;
+};
+
+const saveCardScreenshot = async (id: string, screenshot: Buffer): Promise<void> => {
+  await s3.putObject({
+    Bucket: env.S3_BUCKET_NAME,
+    Key: getScreenshotFileKey(id),
+    Body: screenshot,
+  });
+};
+
+const generateScreenshot = async (_id: string): Promise<Buffer> => {
+  return Promise.resolve(Buffer.from("TODO"));
+};
 
 const isConfigExists = async (id: string): Promise<boolean> => {
   const data = await s3.listObjectsV2({
@@ -42,8 +83,12 @@ const isConfigExists = async (id: string): Promise<boolean> => {
   return contents.length > 0;
 };
 
-const generateConfigId = async (name: string): Promise<string> => {
+const generateConfigId = async (name: string, canOverwrite: boolean): Promise<string> => {
   const id = snakeCase(deburr(name));
+
+  if (canOverwrite) {
+    return id;
+  }
 
   const getUniqueConfigId = async (id: string, index = 0): Promise<string> => {
     const configId = index === 0 ? id : `${id}_${index}`;
@@ -59,8 +104,13 @@ const generateConfigId = async (name: string): Promise<string> => {
   return getUniqueConfigId(id);
 };
 
-export const saveCardConfig = async (cardConfig: CardConfig): Promise<string> => {
-  const id = await generateConfigId(cardConfig.name);
+export const saveCardConfig = async (cardConfig: CreateConfig): Promise<CardConfigInfo> => {
+  const id = await generateConfigId(cardConfig.name, cardConfig.overwrite === true);
+
+  if (cardConfig.generateScreenshot === true) {
+    const screenshot = await generateScreenshot(id);
+    await saveCardScreenshot(id, screenshot);
+  }
 
   await s3.putObject({
     Bucket: env.S3_BUCKET_NAME,
@@ -68,20 +118,52 @@ export const saveCardConfig = async (cardConfig: CardConfig): Promise<string> =>
     Body: JSON.stringify(cardConfig),
   });
 
-  return id;
+  return {
+    name: cardConfig.name,
+    logo: cardConfig.logo,
+    logoScale: cardConfig.logoScale,
+    color: cardConfig.color,
+    shareUrl: `${APP_URL}/share/${id}`,
+    screenshotUrl:
+      cardConfig.generateScreenshot === true ? `${APP_URL}/api/config/${id}/screenshot` : null,
+  };
 };
 
-export const getCardConfig = async (id: string): Promise<Option<CardConfig>> => {
+export const getCardConfig = async (id: string): Promise<Option<CardConfigInfo>> => {
   try {
-    const object = await s3.getObject({
-      Bucket: env.S3_BUCKET_NAME,
-      Key: getConfigFileKey(id),
-    });
+    const [object, screenshotExists] = await Promise.all([
+      s3.getObject({
+        Bucket: env.S3_BUCKET_NAME,
+        Key: getConfigFileKey(id),
+      }),
+      isScreenshotExists(id),
+    ]);
 
     const configFile = (await object.Body?.transformToString()) ?? "{}";
     const config = cardConfigSchema.parse(JSON.parse(configFile));
 
-    return Option.Some(config);
+    return Option.Some({
+      ...config,
+      shareUrl: `${APP_URL}/share/${id}`,
+      screenshotUrl: screenshotExists ? `${APP_URL}/api/config/${id}/screenshot` : null,
+    });
+  } catch {
+    return Option.None();
+  }
+};
+
+export const getScreenshot = async (id: string): Promise<Option<ReadableStream>> => {
+  try {
+    const object = await s3.getObject({
+      Bucket: env.S3_BUCKET_NAME,
+      Key: getScreenshotFileKey(id),
+    });
+
+    if (object.Body === undefined) {
+      return Option.None();
+    }
+
+    return Option.Some(object.Body as ReadableStream);
   } catch {
     return Option.None();
   }

--- a/server/src/utils/cardConfig.ts
+++ b/server/src/utils/cardConfig.ts
@@ -10,8 +10,7 @@ import { z } from "zod";
 import { env } from "./env";
 import { stringifyImage } from "./image";
 
-// const APP_URL = "https://card-design-studio.swan.io";
-const APP_URL = "http://localhost:8080";
+const APP_URL = "https://card-design-studio.swan.io";
 
 const credentials =
   env.AWS_ACCESS_KEY_ID.defined === true && env.AWS_SECRET_ACCESS_KEY.defined === true

--- a/server/src/utils/cardConfig.ts
+++ b/server/src/utils/cardConfig.ts
@@ -126,7 +126,7 @@ const generateScreenshot = async (id: string): Promise<Buffer> => {
     width: SCREENSHOT_WIDTH + CROP_PADDING * 2,
     height: SCREENSHOT_HEIGHT + CROP_PADDING * 2,
   });
-  await page.goto(`${APP_URL}/screenshot/${id}`);
+  await page.goto(`http://localhost:8080/screenshot/${id}`);
 
   await page.waitForLoadState("networkidle");
 

--- a/server/src/utils/cardConfig.ts
+++ b/server/src/utils/cardConfig.ts
@@ -51,6 +51,12 @@ export type CardConfigInfo = CardConfig & {
   screenshotUrl: string | null;
 };
 
+export type CreateConfigResponse = {
+  id: string;
+  screenshotUrl: string | null;
+  shareUrl: string;
+};
+
 const isScreenshotExists = async (id: string): Promise<boolean> => {
   const data = await s3.listObjectsV2({
     Bucket: env.S3_BUCKET_NAME,
@@ -104,7 +110,7 @@ const generateConfigId = async (name: string, canOverwrite: boolean): Promise<st
   return getUniqueConfigId(id);
 };
 
-export const saveCardConfig = async (cardConfig: CreateConfig): Promise<CardConfigInfo> => {
+export const saveCardConfig = async (cardConfig: CreateConfig): Promise<CreateConfigResponse> => {
   const id = await generateConfigId(cardConfig.name, cardConfig.overwrite === true);
 
   if (cardConfig.generateScreenshot === true) {
@@ -119,10 +125,7 @@ export const saveCardConfig = async (cardConfig: CreateConfig): Promise<CardConf
   });
 
   return {
-    name: cardConfig.name,
-    logo: cardConfig.logo,
-    logoScale: cardConfig.logoScale,
-    color: cardConfig.color,
+    id,
     shareUrl: `${APP_URL}/share/${id}`,
     screenshotUrl:
       cardConfig.generateScreenshot === true ? `${APP_URL}/api/config/${id}/screenshot` : null,

--- a/server/src/utils/cardConfig.ts
+++ b/server/src/utils/cardConfig.ts
@@ -1,7 +1,6 @@
 import { S3 } from "@aws-sdk/client-s3";
 import type { MultipartFile } from "@fastify/multipart";
 import { Option } from "@swan-io/boxed";
-import { isNotNullish } from "@swan-io/lake/src/utils/nullish";
 import deburr from "lodash/deburr";
 import snakeCase from "lodash/snakeCase";
 import { chromium } from "playwright";
@@ -61,6 +60,8 @@ export type CreateConfigResponse = {
   screenshotUrl: string | null;
   shareUrl: string;
 };
+
+const isNotNullish = <T>(value: T | null | undefined): value is T => value != null;
 
 export const parseMultiPartFormData = async (data: MultipartFile): Promise<unknown> => {
   const logo = await stringifyImage(data.file, data.mimetype);
@@ -130,7 +131,11 @@ const generateScreenshot = async (id: string): Promise<Buffer> => {
 
   await page.waitForTimeout(1000);
 
-  return page.screenshot();
+  const screenshot = await page.screenshot();
+
+  await browser.close();
+
+  return screenshot;
 };
 
 const isConfigExists = async (id: string): Promise<boolean> => {

--- a/server/src/utils/cardConfig.ts
+++ b/server/src/utils/cardConfig.ts
@@ -115,10 +115,17 @@ const saveCardScreenshot = async (id: string, screenshot: Buffer): Promise<void>
  * It start a browser opening the design studio and take a screenshot.
  */
 const generateScreenshot = async (id: string): Promise<Buffer> => {
+  const SCREENSHOT_WIDTH = 1600;
+  const SCREENSHOT_HEIGHT = 1200;
+  const CROP_PADDING = 75;
+
   const browser = await chromium.launch();
   const context = await browser.newContext();
   const page = await context.newPage();
-  await page.setViewportSize({ width: 1600, height: 1200 });
+  await page.setViewportSize({
+    width: SCREENSHOT_WIDTH + CROP_PADDING * 2,
+    height: SCREENSHOT_HEIGHT + CROP_PADDING * 2,
+  });
   await page.goto(`${APP_URL}/screenshot/${id}`);
 
   await page.waitForLoadState("networkidle");
@@ -131,7 +138,15 @@ const generateScreenshot = async (id: string): Promise<Buffer> => {
 
   await page.waitForTimeout(1000);
 
-  const screenshot = await page.screenshot();
+  // clip the screenshot to hide the the cookie element at bottom left
+  const screenshot = await page.screenshot({
+    clip: {
+      x: CROP_PADDING,
+      y: CROP_PADDING,
+      width: SCREENSHOT_WIDTH,
+      height: SCREENSHOT_HEIGHT,
+    },
+  });
 
   await browser.close();
 

--- a/server/src/utils/cardConfig.ts
+++ b/server/src/utils/cardConfig.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { env } from "./env";
 import { stringifyImage } from "./image";
 
-const APP_URL = "https://card-design-studio.swan.io";
+const APP_URL = env.APP_URL.defined ? env.APP_URL.value : "https://card-design-studio.swan.io";
 
 const credentials =
   env.AWS_ACCESS_KEY_ID.defined === true && env.AWS_SECRET_ACCESS_KEY.defined === true

--- a/server/src/utils/cardConfig.ts
+++ b/server/src/utils/cardConfig.ts
@@ -114,7 +114,7 @@ const generateScreenshot = async (id: string): Promise<Buffer> => {
   const browser = await chromium.launch();
   const context = await browser.newContext();
   const page = await context.newPage();
-  await page.setViewportSize({ width: 1200, height: 630 });
+  await page.setViewportSize({ width: 1600, height: 1200 });
   await page.goto(`${APP_URL}/screenshot/${id}`);
 
   await page.waitForLoadState("networkidle");

--- a/server/src/utils/env.ts
+++ b/server/src/utils/env.ts
@@ -6,6 +6,7 @@ export const env = validate({
   env: process.env,
   validators: {
     NODE_ENV: oneOf("development", "production"),
+    APP_URL: optional(string),
     CLIENT_GOOGLE_TAG_MANAGER_ID: string,
     AWS_ACCESS_KEY_ID: optional(string),
     AWS_SECRET_ACCESS_KEY: optional(string),

--- a/server/src/utils/env.ts
+++ b/server/src/utils/env.ts
@@ -11,6 +11,7 @@ export const env = validate({
     AWS_SECRET_ACCESS_KEY: optional(string),
     AWS_REGION: string,
     S3_BUCKET_NAME: string,
+    S3_ENDPOINT: optional(string),
   },
 });
 

--- a/server/src/utils/image.ts
+++ b/server/src/utils/image.ts
@@ -1,0 +1,30 @@
+import { BusboyFileStream } from "@fastify/busboy";
+import { Result } from "@swan-io/boxed";
+import { match } from "ts-pattern";
+
+export const stringifyImage = async (
+  file: BusboyFileStream,
+  mimetype: string,
+): Promise<Result<string, unknown>> => {
+  if (mimetype !== "image/svg+xml" && mimetype !== "image/png") {
+    return Result.Error(new Error(`Invalid mimetype: ${mimetype}`));
+  }
+
+  try {
+    const chunks: Buffer[] = [];
+
+    for await (const chunk of file) {
+      chunks.push(chunk); // eslint-disable-line @typescript-eslint/no-unsafe-argument
+    }
+
+    const buffer = Buffer.concat(chunks);
+    const string = match(mimetype)
+      .with("image/svg+xml", () => buffer.toString())
+      .with("image/png", () => `data:image/png;base64,${buffer.toString("base64url")}`)
+      .exhaustive();
+
+    return Result.Ok(string);
+  } catch (error) {
+    return Result.Error(error);
+  }
+};

--- a/server/src/utils/image.ts
+++ b/server/src/utils/image.ts
@@ -20,7 +20,7 @@ export const stringifyImage = async (
     const buffer = Buffer.concat(chunks);
     const string = match(mimetype)
       .with("image/svg+xml", () => buffer.toString())
-      .with("image/png", () => `data:image/png;base64,${buffer.toString("base64url")}`)
+      .with("image/png", () => `data:image/png;base64,${buffer.toString("base64")}`)
       .exhaustive();
 
     return Result.Ok(string);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1661,6 +1661,13 @@
     ajv-formats "^2.1.1"
     fast-uri "^2.0.0"
 
+"@fastify/busboy@^1.0.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-1.2.1.tgz#9c6db24a55f8b803b5222753b24fe3aea2ba9ca3"
+  integrity sha512-7PQA7EH43S0CxcOa9OeAnaeA0oQ+e/DHNPZwSQM9CQHW76jle5+OvLdibRp/Aafs9KXbLhxyjOTkRjWUbQEd3Q==
+  dependencies:
+    text-decoding "^1.0.0"
+
 "@fastify/busboy@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.0.0.tgz#f22824caff3ae506b18207bad4126dbc6ccdb6b8"
@@ -1682,6 +1689,18 @@
   integrity sha512-aZAXGYo6m22Fk1zZzEUKBvut/CIIQe/BapEORnxiD5Qr0kPHqqI69NtEMCme74h+at72sPhbkb4ZrLd1W3KRLA==
   dependencies:
     fast-json-stringify "^5.7.0"
+
+"@fastify/multipart@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@fastify/multipart/-/multipart-8.1.0.tgz#92b1cd482202b469b6c08aba568f0cda6fc543ba"
+  integrity sha512-sRX9X4ZhAqRbe2kDvXY2NK7i6Wf1Rm2g/CjpGYYM7+Np8E6uWQXcj761j08qPfPO8PJXM+vJ7yrKbK1GPB+OeQ==
+  dependencies:
+    "@fastify/busboy" "^1.0.0"
+    "@fastify/deepmerge" "^1.0.0"
+    "@fastify/error" "^3.0.0"
+    fastify-plugin "^4.0.0"
+    secure-json-parse "^2.4.0"
+    stream-wormhole "^1.1.0"
 
 "@fastify/reply-from@9.4.0":
   version "9.4.0"
@@ -5343,7 +5362,7 @@ scheduler@^0.23.0:
   dependencies:
     loose-envify "^1.1.0"
 
-secure-json-parse@^2.7.0:
+secure-json-parse@^2.4.0, secure-json-parse@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.7.0.tgz#5a5f9cd6ae47df23dba3151edd06855d47e09862"
   integrity sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==
@@ -5485,6 +5504,11 @@ statuses@2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
+stream-wormhole@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/stream-wormhole/-/stream-wormhole-1.1.0.tgz#300aff46ced553cfec642a05251885417693c33d"
+  integrity sha512-gHFfL3px0Kctd6Po0M8TzEvt3De/xu6cnRrjlfYNhwbhLPLwigI2t1nc6jrzNuaYg5C4YF78PPFuQPzRiqn9ew==
+
 string-argv@0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
@@ -5620,6 +5644,11 @@ terser@5.21.0:
     acorn "^8.8.2"
     commander "^2.20.0"
     source-map-support "~0.5.20"
+
+text-decoding@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/text-decoding/-/text-decoding-1.0.0.tgz#38a5692d23b5c2b12942d6e245599cb58b1bc52f"
+  integrity sha512-/0TJD42KDnVwKmDK6jj3xP7E2MG7SHAOG4tyTgyUCRPdHwvkquYNLEQltmdMa3owq3TkddCVcTsoctJI8VQNKA==
 
 text-table@^0.2.0:
   version "0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1505,115 +1505,230 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.9.1.tgz#4ffb0055f7ef676ebc3a5a91fb621393294e2f43"
   integrity sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ==
 
+"@esbuild/aix-ppc64@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.19.11.tgz#2acd20be6d4f0458bc8c784103495ff24f13b1d3"
+  integrity sha512-FnzU0LyE3ySQk7UntJO4+qIiQgI7KoODnZg5xzXIrFJlKd2P2gwHsHY4927xj9y5PJmJSzULiUCWmv7iWnNa7g==
+
 "@esbuild/android-arm64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz#984b4f9c8d0377443cc2dfcef266d02244593622"
   integrity sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==
+
+"@esbuild/android-arm64@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.19.11.tgz#b45d000017385c9051a4f03e17078abb935be220"
+  integrity sha512-aiu7K/5JnLj//KOnOfEZ0D90obUkRzDMyqd/wNAUQ34m4YUPVhRZpnqKV9uqDGxT7cToSDnIHsGooyIczu9T+Q==
 
 "@esbuild/android-arm@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.18.20.tgz#fedb265bc3a589c84cc11f810804f234947c3682"
   integrity sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==
 
+"@esbuild/android-arm@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.19.11.tgz#f46f55414e1c3614ac682b29977792131238164c"
+  integrity sha512-5OVapq0ClabvKvQ58Bws8+wkLCV+Rxg7tUVbo9xu034Nm536QTII4YzhaFriQ7rMrorfnFKUsArD2lqKbFY4vw==
+
 "@esbuild/android-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.18.20.tgz#35cf419c4cfc8babe8893d296cd990e9e9f756f2"
   integrity sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==
+
+"@esbuild/android-x64@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.19.11.tgz#bfc01e91740b82011ef503c48f548950824922b2"
+  integrity sha512-eccxjlfGw43WYoY9QgB82SgGgDbibcqyDTlk3l3C0jOVHKxrjdc9CTwDUQd0vkvYg5um0OH+GpxYvp39r+IPOg==
 
 "@esbuild/darwin-arm64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz#08172cbeccf95fbc383399a7f39cfbddaeb0d7c1"
   integrity sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==
 
+"@esbuild/darwin-arm64@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.19.11.tgz#533fb7f5a08c37121d82c66198263dcc1bed29bf"
+  integrity sha512-ETp87DRWuSt9KdDVkqSoKoLFHYTrkyz2+65fj9nfXsaV3bMhTCjtQfw3y+um88vGRKRiF7erPrh/ZuIdLUIVxQ==
+
 "@esbuild/darwin-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz#d70d5790d8bf475556b67d0f8b7c5bdff053d85d"
   integrity sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==
+
+"@esbuild/darwin-x64@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.19.11.tgz#62f3819eff7e4ddc656b7c6815a31cf9a1e7d98e"
+  integrity sha512-fkFUiS6IUK9WYUO/+22omwetaSNl5/A8giXvQlcinLIjVkxwTLSktbF5f/kJMftM2MJp9+fXqZ5ezS7+SALp4g==
 
 "@esbuild/freebsd-arm64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz#98755cd12707f93f210e2494d6a4b51b96977f54"
   integrity sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==
 
+"@esbuild/freebsd-arm64@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.19.11.tgz#d478b4195aa3ca44160272dab85ef8baf4175b4a"
+  integrity sha512-lhoSp5K6bxKRNdXUtHoNc5HhbXVCS8V0iZmDvyWvYq9S5WSfTIHU2UGjcGt7UeS6iEYp9eeymIl5mJBn0yiuxA==
+
 "@esbuild/freebsd-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz#c1eb2bff03915f87c29cece4c1a7fa1f423b066e"
   integrity sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==
+
+"@esbuild/freebsd-x64@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.19.11.tgz#7bdcc1917409178257ca6a1a27fe06e797ec18a2"
+  integrity sha512-JkUqn44AffGXitVI6/AbQdoYAq0TEullFdqcMY/PCUZ36xJ9ZJRtQabzMA+Vi7r78+25ZIBosLTOKnUXBSi1Kw==
 
 "@esbuild/linux-arm64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz#bad4238bd8f4fc25b5a021280c770ab5fc3a02a0"
   integrity sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==
 
+"@esbuild/linux-arm64@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.19.11.tgz#58ad4ff11685fcc735d7ff4ca759ab18fcfe4545"
+  integrity sha512-LneLg3ypEeveBSMuoa0kwMpCGmpu8XQUh+mL8XXwoYZ6Be2qBnVtcDI5azSvh7vioMDhoJFZzp9GWp9IWpYoUg==
+
 "@esbuild/linux-arm@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz#3e617c61f33508a27150ee417543c8ab5acc73b0"
   integrity sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==
+
+"@esbuild/linux-arm@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.19.11.tgz#ce82246d873b5534d34de1e5c1b33026f35e60e3"
+  integrity sha512-3CRkr9+vCV2XJbjwgzjPtO8T0SZUmRZla+UL1jw+XqHZPkPgZiyWvbDvl9rqAN8Zl7qJF0O/9ycMtjU67HN9/Q==
 
 "@esbuild/linux-ia32@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz#699391cccba9aee6019b7f9892eb99219f1570a7"
   integrity sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==
 
+"@esbuild/linux-ia32@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.19.11.tgz#cbae1f313209affc74b80f4390c4c35c6ab83fa4"
+  integrity sha512-caHy++CsD8Bgq2V5CodbJjFPEiDPq8JJmBdeyZ8GWVQMjRD0sU548nNdwPNvKjVpamYYVL40AORekgfIubwHoA==
+
 "@esbuild/linux-loong64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz#e6fccb7aac178dd2ffb9860465ac89d7f23b977d"
   integrity sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==
+
+"@esbuild/linux-loong64@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.19.11.tgz#5f32aead1c3ec8f4cccdb7ed08b166224d4e9121"
+  integrity sha512-ppZSSLVpPrwHccvC6nQVZaSHlFsvCQyjnvirnVjbKSHuE5N24Yl8F3UwYUUR1UEPaFObGD2tSvVKbvR+uT1Nrg==
 
 "@esbuild/linux-mips64el@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz#eeff3a937de9c2310de30622a957ad1bd9183231"
   integrity sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==
 
+"@esbuild/linux-mips64el@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.19.11.tgz#38eecf1cbb8c36a616261de858b3c10d03419af9"
+  integrity sha512-B5x9j0OgjG+v1dF2DkH34lr+7Gmv0kzX6/V0afF41FkPMMqaQ77pH7CrhWeR22aEeHKaeZVtZ6yFwlxOKPVFyg==
+
 "@esbuild/linux-ppc64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz#2f7156bde20b01527993e6881435ad79ba9599fb"
   integrity sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==
+
+"@esbuild/linux-ppc64@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.19.11.tgz#9c5725a94e6ec15b93195e5a6afb821628afd912"
+  integrity sha512-MHrZYLeCG8vXblMetWyttkdVRjQlQUb/oMgBNurVEnhj4YWOr4G5lmBfZjHYQHHN0g6yDmCAQRR8MUHldvvRDA==
 
 "@esbuild/linux-riscv64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz#6628389f210123d8b4743045af8caa7d4ddfc7a6"
   integrity sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==
 
+"@esbuild/linux-riscv64@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.19.11.tgz#2dc4486d474a2a62bbe5870522a9a600e2acb916"
+  integrity sha512-f3DY++t94uVg141dozDu4CCUkYW+09rWtaWfnb3bqe4w5NqmZd6nPVBm+qbz7WaHZCoqXqHz5p6CM6qv3qnSSQ==
+
 "@esbuild/linux-s390x@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz#255e81fb289b101026131858ab99fba63dcf0071"
   integrity sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==
+
+"@esbuild/linux-s390x@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.19.11.tgz#4ad8567df48f7dd4c71ec5b1753b6f37561a65a8"
+  integrity sha512-A5xdUoyWJHMMlcSMcPGVLzYzpcY8QP1RtYzX5/bS4dvjBGVxdhuiYyFwp7z74ocV7WDc0n1harxmpq2ePOjI0Q==
 
 "@esbuild/linux-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz#c7690b3417af318a9b6f96df3031a8865176d338"
   integrity sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==
 
+"@esbuild/linux-x64@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.19.11.tgz#b7390c4d5184f203ebe7ddaedf073df82a658766"
+  integrity sha512-grbyMlVCvJSfxFQUndw5mCtWs5LO1gUlwP4CDi4iJBbVpZcqLVT29FxgGuBJGSzyOxotFG4LoO5X+M1350zmPA==
+
 "@esbuild/netbsd-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz#30e8cd8a3dded63975e2df2438ca109601ebe0d1"
   integrity sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==
+
+"@esbuild/netbsd-x64@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.19.11.tgz#d633c09492a1721377f3bccedb2d821b911e813d"
+  integrity sha512-13jvrQZJc3P230OhU8xgwUnDeuC/9egsjTkXN49b3GcS5BKvJqZn86aGM8W9pd14Kd+u7HuFBMVtrNGhh6fHEQ==
 
 "@esbuild/openbsd-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz#7812af31b205055874c8082ea9cf9ab0da6217ae"
   integrity sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==
 
+"@esbuild/openbsd-x64@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.19.11.tgz#17388c76e2f01125bf831a68c03a7ffccb65d1a2"
+  integrity sha512-ysyOGZuTp6SNKPE11INDUeFVVQFrhcNDVUgSQVDzqsqX38DjhPEPATpid04LCoUr2WXhQTEZ8ct/EgJCUDpyNw==
+
 "@esbuild/sunos-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz#d5c275c3b4e73c9b0ecd38d1ca62c020f887ab9d"
   integrity sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==
+
+"@esbuild/sunos-x64@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.19.11.tgz#e320636f00bb9f4fdf3a80e548cb743370d41767"
+  integrity sha512-Hf+Sad9nVwvtxy4DXCZQqLpgmRTQqyFyhT3bZ4F2XlJCjxGmRFF0Shwn9rzhOYRB61w9VMXUkxlBy56dk9JJiQ==
 
 "@esbuild/win32-arm64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz#73bc7f5a9f8a77805f357fab97f290d0e4820ac9"
   integrity sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==
 
+"@esbuild/win32-arm64@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.19.11.tgz#c778b45a496e90b6fc373e2a2bb072f1441fe0ee"
+  integrity sha512-0P58Sbi0LctOMOQbpEOvOL44Ne0sqbS0XWHMvvrg6NE5jQ1xguCSSw9jQeUk2lfrXYsKDdOe6K+oZiwKPilYPQ==
+
 "@esbuild/win32-ia32@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz#ec93cbf0ef1085cc12e71e0d661d20569ff42102"
   integrity sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==
 
+"@esbuild/win32-ia32@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.19.11.tgz#481a65fee2e5cce74ec44823e6b09ecedcc5194c"
+  integrity sha512-6YOrWS+sDJDmshdBIQU+Uoyh7pQKrdykdefC1avn76ss5c+RN6gut3LZA4E2cH5xUEp5/cA0+YxRaVtRAb0xBg==
+
 "@esbuild/win32-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
+
+"@esbuild/win32-x64@0.19.11":
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.19.11.tgz#a5d300008960bb39677c46bf16f53ec70d8dee04"
+  integrity sha512-vfkhltrjCAb603XaFhqhAF4LGDi2M4OrCRrFusyQ+iTLQ/o60QQXxc9cZC/FFpihBI9N1Grn6SMKVJ4KP7Fuiw==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
   version "4.4.0"
@@ -3497,7 +3612,7 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-esbuild@^0.18.10, esbuild@~0.18.20:
+esbuild@^0.18.10:
   version "0.18.20"
   resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.18.20.tgz#4709f5a34801b43b799ab7d6d82f7284a9b7a7a6"
   integrity sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==
@@ -3524,6 +3639,35 @@ esbuild@^0.18.10, esbuild@~0.18.20:
     "@esbuild/win32-arm64" "0.18.20"
     "@esbuild/win32-ia32" "0.18.20"
     "@esbuild/win32-x64" "0.18.20"
+
+esbuild@~0.19.10:
+  version "0.19.11"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.19.11.tgz#4a02dca031e768b5556606e1b468fe72e3325d96"
+  integrity sha512-HJ96Hev2hX/6i5cDVwcqiJBBtuo9+FeIJOtZ9W1kA5M6AMJRHUZlpYZ1/SbEwtO0ioNAW8rUooVpC/WehY2SfA==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.19.11"
+    "@esbuild/android-arm" "0.19.11"
+    "@esbuild/android-arm64" "0.19.11"
+    "@esbuild/android-x64" "0.19.11"
+    "@esbuild/darwin-arm64" "0.19.11"
+    "@esbuild/darwin-x64" "0.19.11"
+    "@esbuild/freebsd-arm64" "0.19.11"
+    "@esbuild/freebsd-x64" "0.19.11"
+    "@esbuild/linux-arm" "0.19.11"
+    "@esbuild/linux-arm64" "0.19.11"
+    "@esbuild/linux-ia32" "0.19.11"
+    "@esbuild/linux-loong64" "0.19.11"
+    "@esbuild/linux-mips64el" "0.19.11"
+    "@esbuild/linux-ppc64" "0.19.11"
+    "@esbuild/linux-riscv64" "0.19.11"
+    "@esbuild/linux-s390x" "0.19.11"
+    "@esbuild/linux-x64" "0.19.11"
+    "@esbuild/netbsd-x64" "0.19.11"
+    "@esbuild/openbsd-x64" "0.19.11"
+    "@esbuild/sunos-x64" "0.19.11"
+    "@esbuild/win32-arm64" "0.19.11"
+    "@esbuild/win32-ia32" "0.19.11"
+    "@esbuild/win32-x64" "0.19.11"
 
 escalade@^3.1.1:
   version "3.1.1"
@@ -5490,7 +5634,7 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
-source-map-support@^0.5.21, source-map-support@~0.5.20:
+source-map-support@~0.5.20:
   version "0.5.21"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
@@ -5780,14 +5924,13 @@ tslib@^2.3.1, tslib@^2.4.0, tslib@^2.5.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
-tsx@3.13.0:
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/tsx/-/tsx-3.13.0.tgz#f860e511b33fcb41d74df87d7ba239a0b4012dbb"
-  integrity sha512-rjmRpTu3as/5fjNq/kOkOtihgLxuIz6pbKdj9xwP4J5jOLkBxw/rjN5ANw+KyrrOXV5uB7HC8+SrrSJxT65y+A==
+tsx@4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/tsx/-/tsx-4.7.0.tgz#1689cfe7dda495ca1f9a66d4cad79cb57b9f6f4a"
+  integrity sha512-I+t79RYPlEYlHn9a+KzwrvEwhJg35h/1zHsLC2JXvhC2mdynMv6Zxzvhv5EMV6VF5qJlLlkSnMVvdZV3PSIGcg==
   dependencies:
-    esbuild "~0.18.20"
+    esbuild "~0.19.10"
     get-tsconfig "^4.7.2"
-    source-map-support "^0.5.21"
   optionalDependencies:
     fsevents "~2.3.3"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3909,6 +3909,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -4929,6 +4934,20 @@ pino@^8.16.0:
     safe-stable-stringify "^2.3.1"
     sonic-boom "^3.7.0"
     thread-stream "^2.0.0"
+
+playwright-core@1.41.1:
+  version "1.41.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.41.1.tgz#9c152670010d9d6f970f34b68e3e935d3c487431"
+  integrity sha512-/KPO5DzXSMlxSX77wy+HihKGOunh3hqndhqeo/nMxfigiKzogn8kfL0ZBDu0L1RKgan5XHCPmn6zXd2NUJgjhg==
+
+playwright@1.41.1:
+  version "1.41.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.41.1.tgz#83325f34165840d019355c2a78a50f21ed9b9c85"
+  integrity sha512-gdZAWG97oUnbBdRL3GuBvX3nDDmUOuqzV/D24dytqlKt+eI5KbwusluZRGljx1YoJKZ2NRPaeWiFTeGZO7SosQ==
+  dependencies:
+    playwright-core "1.41.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 polished@^4.2.2:
   version "4.2.2"


### PR DESCRIPTION
> This PR is a copy of this PR with signed commits: https://github.com/swan-io/card-design-studio/pull/5

This PR contains a new version of card design studio based on this previous PR: https://github.com/swan-io/card-design-studio/pull/4

The goal is providing the possibility to marketing team to create new cards automatically with an http request and generate a screenshots.

List of changes:
add the possibility to create a config from API call by accepting multipart/form-data
add an option to generate a screenshot
add an option to overwrite a config
Env variable changes
I added the env variable APP_URL. The default value is https://card-design-studio.swan.io but for preproduction, we need to set this variable to https://card-design-studio.preprod.swan.io

Technical details
To generate screenshots:

the server starts a headless chrome with playwright
open a specific page of the card studio
close the cookie popup
take the screenshot
close the browser
To make playwright working in the browser, I had to change the docker file because I didn't manage to install playwright on chainguard image. So the docker image size comes from 500Mo to 4.3Go. I know this is huge but I didn't find another way to make playwright working.